### PR TITLE
Fix for Module.php to fit InitProviderInterface update

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -2,7 +2,7 @@
 
 namespace AsseticBundle;
 
-use Zend\ModuleManager\ModuleManager,
+use Zend\ModuleManager\ModuleManagerInterface,
     Zend\Http\Response,
     Zend\EventManager\Event,
     Zend\EventManager\StaticEventManager,
@@ -31,10 +31,10 @@ class Module implements InitProviderInterface, AutoloaderProviderInterface, Conf
     /**
      * Initialize workflow
      *
-     * @param  \Zend\ModuleManager\ModuleManager $manager
+     * @param  \Zend\ModuleManager\ModuleManagerInterface $manager
      * @return void
      */
-    public function init($manager = null)
+    public function init(ModuleManagerInterface $manager)
     {
         $this->moduleManager = $manager;
     }


### PR DESCRIPTION
The module is broken regarding an update on zf2 library (Update on InitProviderInterface)

https://github.com/zendframework/zf2/commit/c494fb200a8eb511a1f05f49eed3ada472e4b09c
