### PR TITLE
Exposed service configuration via public method

### DIFF
--- a/src/AsseticBundle/Service.php
+++ b/src/AsseticBundle/Service.php
@@ -346,4 +346,14 @@ class Service
     {
         return get_class($renderer);
     }
+
+    /**
+     * Gets the service configuration.
+     *
+     * @return Configuration
+     */
+    public function getConfiguration()
+    {
+        return $this->configuration;
+    }
 }


### PR DESCRIPTION
Allows access to the configuration. This can be useful when accessing assetic via the service manager.
Eg:
/*\* @var $as \AsseticBundle\Service */
$as = $e->getApplication()->getServiceManager()->get('AsseticService');
$as->getConfiguration()->getBaseUrl()
