### PR TITLE
Fix issue #52

### DIFF
--- a/src/AsseticBundle/Service.php
+++ b/src/AsseticBundle/Service.php
@@ -172,19 +172,26 @@ class Service
                 }
             }
 
-            // Insert last modified timestamps into the file names
+            // Insert last modified timestamps into names of JS and CSS files.
             foreach ($this->assetManager->getNames() as $name) {
                 $asset = $this->assetManager->get($name);
 
-                $lastModified = $asset->getLastModified();
-                if (null !== $lastModified)
+                $path = $asset->getTargetPath();
+                $ext  = pathinfo($path, PATHINFO_EXTENSION);
+
+                if ('css' == $ext || 'js' == $ext)
                 {
-                    $path = $asset->getTargetPath();
-                    $ext  = pathinfo($path, PATHINFO_EXTENSION);
+                    $lastModified = $asset->getLastModified();
+                    if (null !== $lastModified)
+                    {
+                        $path = substr_replace(
+                            $path,
+                            "$lastModified.$ext",
+                            -1 * strlen($ext)
+                        );
 
-                    $path = str_replace($ext, "$lastModified.$ext", $path);
-
-                    $asset->setTargetPath($path);
+                        $asset->setTargetPath($path);
+                    }
                 }
             }
 

--- a/tests/AsseticBundleTest/Service.php
+++ b/tests/AsseticBundleTest/Service.php
@@ -157,14 +157,22 @@ class Service extends \PHPUnit_Framework_TestCase
     }
 
     public function testInitLoadedModules() {
-        $loadModules = array(
-            'test_application' => 'test_application',
-        );
+        $loadModules = array('test_application' => 'test_application');
         $this->object->initLoadedModules($loadModules);
         $assetManager = $this->object->getAssetManager();
+
         $this->assertTrue($assetManager->has('base_css'));
         $this->assertTrue($assetManager->has('base_js'));
         $this->assertFalse($assetManager->has('base_images'));
+
+        $assetFile = $assetManager->get('base_css')->getTargetPath();
+        $this->assertTrue(
+            (bool) preg_match('/^base_css.\d+.css$/', $assetFile)
+        );
+        $assetFile = $assetManager->get('base_js')->getTargetPath();
+        $this->assertTrue(
+            (bool) preg_match('/^base_js.\d+.js$/', $assetFile)
+        );
     }
 
     public function testGetRendererName() {

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -6,18 +6,4 @@ define('TEST_ASSETS_DIR', __DIR__ . '/assets');
 define('TEST_CACHE_DIR', __DIR__ . '/cache');
 define('TEST_PUBLIC_DIR', __DIR__ . '/public');
 
-/**
- * Simple autoloader
- */
-spl_autoload_register(function($className){
-    $className = ltrim($className, '\\');
-    $fileName  = '';
-    if ($lastNsPos = strripos($className, '\\')) {
-        $namespace = substr($className, 0, $lastNsPos);
-        $className = substr($className, $lastNsPos + 1);
-        $fileName  = str_replace('\\', DIRECTORY_SEPARATOR, $namespace) . DIRECTORY_SEPARATOR;
-    }
-    $fileName .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
-
-    require $fileName;
-});
+require '../vendor/autoload.php';


### PR DESCRIPTION
Modified code that inserts a last modified timestamp into asset file names so that only CSS and JS assets are affected, and so that the timestamp is only inserted into the file name once, just before the file extension.
