### PR TITLE
Allow the configuration of "acceptable errors"

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -92,15 +92,11 @@ class Module
 
     public function renderAssets(MvcEvent $e)
     {
+        $sm     = $e->getApplication()->getServiceManager();
+        $config = $sm->get('AsseticConfiguration');
         if ($e->getName() === MvcEvent::EVENT_DISPATCH_ERROR) {
             $error = $e->getError();
-            if ($error && !in_array($error, array(
-                    Application::ERROR_CONTROLLER_NOT_FOUND,
-                    Application::ERROR_CONTROLLER_INVALID,
-                    Application::ERROR_ROUTER_NO_MATCH
-                ))
-            )
-            {
+            if ($error && !in_array($error, $config->getAcceptableErrors())) {
                 // break if not an acceptable error
                 return;
             }
@@ -111,9 +107,6 @@ class Module
             $response = new Response();
             $e->setResponse($response);
         }
-
-        $sm = $e->getApplication()->getServiceManager();
-
 
         /** @var $asseticService \AsseticBundle\Service */
         $asseticService = $sm->get('AsseticService');

--- a/configs/module.config.php
+++ b/configs/module.config.php
@@ -2,10 +2,12 @@
 return array(
     'service_manager'       => array(
         'aliases'   => array(
+            'AsseticConfiguration' => 'AsseticBundle\Configuration',
             'AsseticService'       => 'AsseticBundle\Service',
         ),
         'factories' => array(
-            'AsseticBundle\Service' => 'AsseticBundle\ServiceFactory',
+            'AsseticBundle\Configuration' => 'AsseticBundle\ConfigurationFactory',
+            'AsseticBundle\Service'       => 'AsseticBundle\ServiceFactory',
         ),
         'invokables' => array(
             'Assetic\AssetManager' => 'Assetic\AssetManager',
@@ -28,6 +30,11 @@ return array(
             'Zend\View\Renderer\PhpRenderer'  => 'AsseticBundle\View\ViewHelperStrategy',
             'Zend\View\Renderer\FeedRenderer' => 'AsseticBundle\View\NoneStrategy',
             'Zend\View\Renderer\JsonRenderer' => 'AsseticBundle\View\NoneStrategy',
+        ),
+        'acceptableErrors' => array(
+            \Zend\Mvc\Application::ERROR_CONTROLLER_NOT_FOUND,
+            \Zend\Mvc\Application::ERROR_CONTROLLER_INVALID,
+            \Zend\Mvc\Application::ERROR_ROUTER_NO_MATCH
         ),
         'routes'             => array(),
         'modules'            => array(),

--- a/src/AsseticBundle/Configuration.php
+++ b/src/AsseticBundle/Configuration.php
@@ -101,6 +101,8 @@ class Configuration
      */
     protected $rendererToStrategy = array();
 
+    protected $acceptableErrors = array();
+
     public function __construct($config = null)
     {
         if (null !== $config) {
@@ -333,5 +335,15 @@ class Configuration
         return array_key_exists($rendererName, $this->rendererToStrategy)
             ? $this->rendererToStrategy[$rendererName]
             : $default;
+    }
+
+    public function setAcceptableErrors(array $acceptableErrors)
+    {
+        $this->acceptableErrors = $acceptableErrors;
+    }
+
+    public function getAcceptableErrors()
+    {
+        return $this->acceptableErrors;
     }
 }

--- a/src/AsseticBundle/ConfigurationFactory.php
+++ b/src/AsseticBundle/ConfigurationFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AsseticBundle;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ConfigurationFactory implements FactoryInterface
+{
+    /**
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return \AsseticBundle\Configuration
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $configuration = $serviceLocator->get('Configuration');
+        return new Configuration($configuration['assetic_configuration']);
+    }
+}

--- a/src/AsseticBundle/ServiceFactory.php
+++ b/src/AsseticBundle/ServiceFactory.php
@@ -12,11 +12,9 @@ class ServiceFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $configuration = $serviceLocator->get('Configuration');
-
-        $asseticConfig = new Configuration($configuration['assetic_configuration']);
-        $asseticAssetManager = $serviceLocator->get('Assetic\AssetManager');
-        $asseticFilterManager = $serviceLocator->get('Assetic\FilterManager');
+        $asseticConfig        = $serviceLocator->get('AsseticConfiguration');
+        $asseticAssetManager  = $serviceLocator->get('AsseticAssetManager');
+        $asseticFilterManager = $serviceLocator->get('AsseticFilterManager');
 
         // inject base url & path
         if ($asseticConfig->detectBaseUrl()) {


### PR DESCRIPTION
Assets are not included if the dispatch error is not in whitelist of
allowed errors.
The BjyAuthorize module throws a \BjyAuthorize\Guard\Route::ERROR
error, which should still include assets
