### PR TITLE
Don't add lastModified to filename with move_raw

### DIFF
--- a/src/AsseticBundle/Service.php
+++ b/src/AsseticBundle/Service.php
@@ -143,6 +143,7 @@ class Service
             $factory->setDebug($this->configuration->isDebug());
 
             $collections = (array) $conf['collections'];
+
             foreach($collections as $name => $options)
             {
                 $assets  = isset($options['assets']) ? $options['assets'] : array();
@@ -179,7 +180,7 @@ class Service
                 $path = $asset->getTargetPath();
                 $ext  = pathinfo($path, PATHINFO_EXTENSION);
 
-                if ('css' == $ext || 'js' == $ext)
+                if ((!isset($options['move_raw']) || $options['move_raw'] != true) && ('css' == $ext || 'js' == $ext))
                 {
                     $lastModified = $asset->getLastModified();
                     if (null !== $lastModified)


### PR DESCRIPTION
If using `move_raw` to copy JS/CSS, don't add the timestamp, as it is likely to be included on the page manually.

**Note:** The travis builds all failed before they could even run tests. Please run the tests yourself to verify :)
