### PR TITLE
Call setter on filter obj if set$optionkey exists

### DIFF
--- a/src/AsseticBundle/Service.php
+++ b/src/AsseticBundle/Service.php
@@ -241,6 +241,15 @@ class Service
                     call_user_func_array(array($filter, '__construct'), $option);
                 }
 
+                $filterOptions = $options;
+                unset($options['name']);
+                unset($options['option']);
+                foreach ($filterOptions as $key => $value) {
+                    if (method_exists($filter, 'set' .$key)) {
+                        $filter->{'set' .$key}($value);
+                    }
+                }
+
                 $fm->set($alias, $filter);
             }
 


### PR DESCRIPTION
This allows you to do things like set the Scss/Sass filter style for
minification.

``` php
<?php
return array(
    ...
    'filters' => array(
        'SassFilter' => array(
            'name' => 'Assetic\Filter\Sass\SassFilter',
            'style' => 'compressed', /* call
$filter->setStyle('compressed'); */
        ),
    ),
);
```
