### PR TITLE
Mixin config does not work as intended

### DIFF
--- a/src/AsseticBundle/Service.php
+++ b/src/AsseticBundle/Service.php
@@ -261,7 +261,7 @@ class Service
         // If we don't have any assets listed by now, or if we are mixing in
         // the default assets, then merge in the default assets to the config array
         $defaultConfig = $this->getDefaultConfig();
-        if (count($config) == 0 || isset($defaultConfig['options']['mixin'])) {
+        if (count($config) == 0 || (isset($defaultConfig['options']['mixin']) && $defaultConfig['options']['mixin'])) {
             $config = array_merge($config, $defaultConfig['assets']);
         }
 


### PR DESCRIPTION
The mixin config does not work as intended. It gets ignored because the check for `isset($defaultConfig['options']['mixin']` returns true in any case (config value false or true). I corrected this issue.
