### PR TITLE
Add AssetFactory to buster interface

### DIFF
--- a/src/AsseticBundle/CacheBuster/LastModifiedStrategy.php
+++ b/src/AsseticBundle/CacheBuster/LastModifiedStrategy.php
@@ -3,11 +3,12 @@
 namespace AsseticBundle\CacheBuster;
 
 use Assetic\Asset\AssetInterface,
-    Assetic\Factory\Worker\WorkerInterface;
+    Assetic\Factory\Worker\WorkerInterface,
+    Assetic\Factory\AssetFactory;
 
 class LastModifiedStrategy implements WorkerInterface
 {
-    public function process(AssetInterface $asset)
+    public function process(AssetInterface $asset, AssetFactory $factory)
     {
         $path = $asset->getTargetPath();
         $ext  = pathinfo($path, PATHINFO_EXTENSION);

--- a/src/AsseticBundle/CacheBuster/Null.php
+++ b/src/AsseticBundle/CacheBuster/Null.php
@@ -3,11 +3,12 @@
 namespace AsseticBundle\CacheBuster;
 
 use Assetic\Asset\AssetInterface,
-    Assetic\Factory\Worker\WorkerInterface;
+    Assetic\Factory\Worker\WorkerInterface,
+    Assetic\Factory\AssetFactory;
 
 class Null implements WorkerInterface
 {
-    public function process(AssetInterface $asset)
+    public function process(AssetInterface $asset, AssetFactory $factory)
     {
     }
 }


### PR DESCRIPTION
Assetic now has `AssetFactory` added to the `WorkerInterface`. Please see https://github.com/kriswallsmith/assetic/commit/01d4d8355b7541475985bf1c1fd54edd6eac57aa#src/Assetic/Factory/Worker/WorkerInterface.php

This PR adds the same parameter to the worker implementations
