### PR TITLE
Serve static files with combine=false and debug=true.

### DIFF
--- a/src/AsseticBundle/Listener.php
+++ b/src/AsseticBundle/Listener.php
@@ -3,9 +3,10 @@ namespace AsseticBundle;
 
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\ListenerAggregateInterface;
+use Zend\Http\Header\LastModified;
 use Zend\Http\PhpEnvironment\Response;
+use Zend\Mvc\Application;
 use Zend\Mvc\MvcEvent;
-use Zend\Stdlib\CallbackHandler;
 
 class Listener implements ListenerAggregateInterface
 {
@@ -26,6 +27,7 @@ class Listener implements ListenerAggregateInterface
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH, array($this, 'renderAssets'), 32);
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($this, 'renderAssets'), 32);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, array($this, 'serveStaticAssets'), 31);
     }
 
     /**
@@ -39,6 +41,83 @@ class Listener implements ListenerAggregateInterface
             if ($events->detach($listener)) {
                 unset($this->listeners[$index]);
             }
+        }
+    }
+
+    public function serveStaticAssets(MvcEvent $e)
+    {
+        $sm     = $e->getApplication()->getServiceManager();
+        /** @var Configuration $config */
+        $config = $sm->get('AsseticConfiguration');
+        if($config->isCombine() || !$config->isDebug()) {
+            // combine must be disabled and debug enabled
+            return;
+        }
+
+        $error = $e->getError();
+        if ($error && !in_array($error, array(
+                Application::ERROR_CONTROLLER_NOT_FOUND,
+                Application::ERROR_CONTROLLER_INVALID,
+                Application::ERROR_ROUTER_NO_MATCH,
+        ))){
+            // this should only be invoked for 404 errors
+            return;
+        }
+
+        $response = $e->getResponse();
+        if (!$response) {
+            $response = new Response();
+            $e->setResponse($response);
+        }
+
+        /** @var $asseticService \AsseticBundle\Service */
+        $asseticService = $sm->get('AsseticService');
+
+        // could not find any renderer, so we'll try to match the request URI against asset's target path
+        if($asset = $asseticService->findAssetForRequest($e->getRequest())){
+
+            if(count($asset->getFilters())) {
+                $dump = $asset->dump();
+                $path = tempnam(sys_get_temp_dir(), 'asset-dump');
+                file_put_contents($path, $dump);
+            } else {
+                $path = $asset->getSourceRoot() . '/' . $asset->getSourcePath();
+            }
+
+            $lastModified = new LastModified();
+            $date = new \DateTime();
+            $date->setTimestamp($asset->getLastModified());
+            $lastModified->setDate($date);
+
+            $headers = $response->getHeaders();
+            $headers->addHeaderLine('Content-Length', filesize($path));
+            $headers->addHeader($lastModified);
+            $response->setContent(file_get_contents($path));
+            $response->setStatusCode(200);
+
+            $ext = pathinfo($asset->getTargetPath(), PATHINFO_EXTENSION);
+            if($ext == 'css') {
+                $headers->addHeaderLine('Content-Type', 'text/css');
+            }elseif($ext == 'js') {
+                $headers->addHeaderLine('Content-Type', 'text/javascript');
+            } elseif (function_exists('finfo_open')) {
+                $db = @finfo_open(FILEINFO_MIME);
+
+                if ($db) {
+                    if($mimeType = finfo_file($db, $path)) {
+                        $headers->addHeaderLine('Content-Type', $mimeType);
+                    }
+                }
+            }
+
+            // remove temp file
+            if(count($asset->getFilters())) {
+                unlink($path);
+            }
+
+            $e->stopPropagation(true);
+
+            return $response;
         }
     }
 
@@ -64,6 +143,8 @@ class Listener implements ListenerAggregateInterface
         /** @var $asseticService \AsseticBundle\Service */
         $asseticService = $sm->get('AsseticService');
 
+        $asseticService->setRequest($e->getRequest());
+
         // setup service if a matched route exist
         $router = $e->getRouteMatch();
         if ($router) {
@@ -76,6 +157,6 @@ class Listener implements ListenerAggregateInterface
         $asseticService->build();
 
         // Init assets for modules
-        $asseticService->setupRenderer($sm->get('ViewRenderer'));
-    }
+        $setup = $asseticService->setupRenderer($sm->get('ViewRenderer'));
+   }
 }

--- a/src/AsseticBundle/Listener.php
+++ b/src/AsseticBundle/Listener.php
@@ -157,6 +157,6 @@ class Listener implements ListenerAggregateInterface
         $asseticService->build();
 
         // Init assets for modules
-        $setup = $asseticService->setupRenderer($sm->get('ViewRenderer'));
+        $asseticService->setupRenderer($sm->get('ViewRenderer'));
    }
 }

--- a/src/AsseticBundle/Listener.php
+++ b/src/AsseticBundle/Listener.php
@@ -159,8 +159,6 @@ class Listener implements ListenerAggregateInterface
         /** @var $asseticService \AsseticBundle\Service */
         $asseticService = $sm->get('AsseticService');
 
-        $asseticService->setRequest($e->getRequest());
-
         // setup service if a matched route exist
         $router = $e->getRouteMatch();
         if ($router) {

--- a/src/AsseticBundle/Service.php
+++ b/src/AsseticBundle/Service.php
@@ -10,6 +10,8 @@ use Assetic\AssetWriter;
 use Assetic\Asset\AssetInterface;
 use Assetic\Asset\AssetCache;
 use Assetic\Cache\FilesystemCache;
+use Zend\Http\Request as HttpRequest;
+use Zend\Stdlib\RequestInterface;
 use Zend\View\Renderer\RendererInterface as Renderer;
 use AsseticBundle\View\StrategyInterface;
 
@@ -61,6 +63,11 @@ class Service
      * @var \Assetic\AsseticFilterManager
      */
     protected $filterManager;
+
+    /**
+     * @var RequestInterface
+     */
+    protected $request;
 
     public function __construct(Configuration $configuration)
     {
@@ -160,6 +167,24 @@ class Service
     }
 
     /**
+     * @param \Zend\Stdlib\RequestInterface $request
+     */
+    public function setRequest(RequestInterface $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @return \Zend\Stdlib\RequestInterface
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+
+
+    /**
      * Build collection of assets.
      */
     public function build()
@@ -250,6 +275,39 @@ class Service
         }
 
         return false;
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return AssetInterface|null
+     */
+    public function findAssetForRequest(RequestInterface $request)
+    {
+        // Try to find the asset via targetPath in any of the defined modules
+        if($request instanceof HttpRequest) {
+            $uri = ltrim($request->getUri()->getPath(),'/');
+
+            $moduleConfiguration = $this->configuration->getModules();
+            foreach ($moduleConfiguration as $configuration) {
+                $factory = $this->createAssetFactory($configuration);
+                $collections = (array)$configuration['collections'];
+                foreach ($collections as $name => $options) {
+                    $assets = isset($options['assets']) ? $options['assets'] : array();
+                    $filters = isset($options['filters']) ? $options['filters'] : array();
+                    $options = isset($options['options']) ? $options['options'] : array();
+                    $options['output'] = isset($options['output']) ? $options['output'] : $name;
+
+                    $filters = $this->initFilters($filters);
+                    $collection = $factory->createAsset($assets, $filters, $options);
+                    foreach($collection as $asset) {
+                        /** @var $asset AssetInterface */
+                        if($asset->getTargetPath() == $uri) {
+                            return $asset;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     public function getDefaultConfig()
@@ -369,7 +427,6 @@ class Service
     {
         return $this->configuration;
     }
-
 
     /**
      * @param array $configuration

--- a/src/AsseticBundle/Service.php
+++ b/src/AsseticBundle/Service.php
@@ -64,11 +64,6 @@ class Service
      */
     protected $filterManager;
 
-    /**
-     * @var RequestInterface
-     */
-    protected $request;
-
     public function __construct(Configuration $configuration)
     {
         $this->configuration = $configuration;
@@ -165,24 +160,6 @@ class Service
     {
         return $this->actionName;
     }
-
-    /**
-     * @param \Zend\Stdlib\RequestInterface $request
-     */
-    public function setRequest(RequestInterface $request)
-    {
-        $this->request = $request;
-    }
-
-    /**
-     * @return \Zend\Stdlib\RequestInterface
-     */
-    public function getRequest()
-    {
-        return $this->request;
-    }
-
-
 
     /**
      * Build collection of assets.


### PR DESCRIPTION
When using ...

``` php
'debug'   => true,
'combine' => false
```

... assetic module was including individual files from a collection, for example:

``` html
<script type="text/javascript" src="/js/main_bootstrap.min_1.js"></script>
<script type="text/javascript" src="/js/main_json2_2.js"></script>
<script type="text/javascript" src="/js/main_modernizr_3.js"></script>
<script type="text/javascript" src="/js/main_main_4.js"></script>
```

... however, it was unable to serve them which resulted in **error 404**. This PR fixes this and allows for serving static files based on `$asset->getTargetPath()`.

Please review and send in feedback. If you like the direction I'll add tests and fix docs.
