### PR TITLE
avoid usind ServiceLocatorAwareInterface since it has been deprecated

### DIFF
--- a/configs/module.config.php
+++ b/configs/module.config.php
@@ -20,10 +20,10 @@ return array(
         'factories' => array(
             'AsseticBundle\Service' => 'AsseticBundle\ServiceFactory',
             'Assetic\AssetWriter' => 'AsseticBundle\WriterFactory',
+            'AsseticBundle\FilterManager'  => 'AsseticBundle\FilterManagerFactory',
         ),
         'invokables' => array(
             'Assetic\AssetManager'   => 'Assetic\AssetManager',
-            'AsseticBundle\FilterManager'  => 'AsseticBundle\FilterManager',
             'AsseticBundle\Listener' => 'AsseticBundle\Listener',
         ),
         'initializers' => array(

--- a/src/AsseticBundle/FilterManager.php
+++ b/src/AsseticBundle/FilterManager.php
@@ -3,10 +3,9 @@ namespace AsseticBundle;
 
 use Assetic\Filter\FilterInterface;
 use Assetic\FilterManager as AsseticFilterManager;
-use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
-class FilterManager extends AsseticFilterManager implements ServiceLocatorAwareInterface
+class FilterManager extends AsseticFilterManager
 {
     /**
      * @var ServiceLocatorInterface
@@ -14,24 +13,11 @@ class FilterManager extends AsseticFilterManager implements ServiceLocatorAwareI
     protected $serviceLocator;
 
     /**
-     * Set service locator
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return mixed
+     * @param ServiceLocatorInterface $locator
      */
-    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    public function __construct(ServiceLocatorInterface $locator)
     {
-        $this->serviceLocator = $serviceLocator;
-    }
-
-    /**
-     * Get service locator
-     *
-     * @return ServiceLocatorInterface
-     */
-    public function getServiceLocator()
-    {
-        return $this->serviceLocator;
+        $this->serviceLocator = $locator;
     }
 
     /**
@@ -40,7 +26,7 @@ class FilterManager extends AsseticFilterManager implements ServiceLocatorAwareI
      */
     public function has($alias)
     {
-        return parent::has($alias) ? true : $this->getServiceLocator()->has($alias);
+        return parent::has($alias) ? true : $this->serviceLocator->has($alias);
     }
 
     /**
@@ -54,7 +40,7 @@ class FilterManager extends AsseticFilterManager implements ServiceLocatorAwareI
             return parent::get($alias);
         }
 
-        $service = $this->getServiceLocator();
+        $service = $this->serviceLocator;
         if (!$service->has($alias)) {
             throw new \InvalidArgumentException(sprintf('There is no "%s" filter in ZF2 service manager.', $alias));
         }

--- a/src/AsseticBundle/FilterManagerFactory.php
+++ b/src/AsseticBundle/FilterManagerFactory.php
@@ -1,0 +1,21 @@
+<?php
+namespace AsseticBundle;
+
+use AsseticBundle\FilterManager;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FilterManagerFactory implements FactoryInterface
+{
+    /**
+     * @param ServiceLocatorInterface $locator
+     * @return \AsseticBundle\FilterManager
+     */
+    public function createService(ServiceLocatorInterface $locator)
+    {
+        $filterManager = new FilterManager($locator);
+
+        return $filterManager;
+    }
+}

--- a/tests/AsseticBundleTest/FilterManager.php
+++ b/tests/AsseticBundleTest/FilterManager.php
@@ -26,8 +26,7 @@ class FilterManager extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->service = new ServiceManager\ServiceManager();
-        $this->object = new AsseticBundle\FilterManager();
-        $this->object->setServiceLocator($this->service);
+        $this->object = new AsseticBundle\FilterManager($this->service);
     }
 
     /**
@@ -36,10 +35,6 @@ class FilterManager extends \PHPUnit_Framework_TestCase
      */
     protected function tearDown()
     {}
-
-    public function testGetServiceLocator() {
-        $this->assertSame($this->service, $this->object->getServiceLocator());
-    }
 
     /**
      * @dataProvider getAliasHasFalseProvider


### PR DESCRIPTION
Regarding issue #143 FilterManager is now initialized with a Factory to not rely on ServiceLocatorAwareInterface which is deprecated since [zend-mvc 2.7.0](https://github.com/zendframework/zend-mvc/releases/tag/release-2.7.0) and will be removed in ZF3.