### PR TITLE
Update Assets based on the LastModified of all depedencies

### DIFF
--- a/src/AsseticBundle/View/Helper/Asset.php
+++ b/src/AsseticBundle/View/Helper/Asset.php
@@ -50,7 +50,6 @@ class Asset extends Container\AbstractStandalone
         }
 
         $asset = $this->service->getAssetManager()->get($collectionName);
-        $this->service->writeAsset($asset);
 
         return $this->setupAsset($asset, $options);
     }

--- a/tests/AsseticBundleTest/Service.php
+++ b/tests/AsseticBundleTest/Service.php
@@ -246,14 +246,15 @@ class Service extends \PHPUnit_Framework_TestCase
         $this->object->build();
 
         $manager = $this->object->getAssetManager();
-        $asset = $manager->get('base_css');
+        $factory = $this->object->createAssetFactory($this->configuration->getModule('test_application'));
+        $asset   = $manager->get('base_css');
         $targetFile = $this->configuration->getWebPath($asset->getTargetPath());
         if (is_file($targetFile)) {
             unlink($targetFile);
         }
 
         $this->assertFileNotExists($targetFile);
-        $this->object->writeAsset($asset);
+        $this->object->writeAsset($asset, $factory);
         $this->assertFileExists($targetFile);
     }
 
@@ -264,7 +265,8 @@ class Service extends \PHPUnit_Framework_TestCase
         $this->object->build();
 
         $manager = $this->object->getAssetManager();
-        $assets = $manager->get('base_css')->all();
+        $assets  = $manager->get('base_css')->all();
+        $factory = $this->object->createAssetFactory($this->configuration->getModule('test_application'));
 
         /** @var \Assetic\Asset\AssetInterface $asset */
         $asset = $assets[0];
@@ -275,7 +277,7 @@ class Service extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertFileNotExists($targetFile);
-        $this->object->writeAsset($asset);
+        $this->object->writeAsset($asset, $factory);
         $this->assertFileExists($targetFile);
 
         $sourceFile = $asset->getSourceRoot() . '/' . $asset->getSourcePath();
@@ -292,7 +294,7 @@ class Service extends \PHPUnit_Framework_TestCase
         $modifiedAsset = new FileAsset($sourceFile);
         $modifiedAsset->setTargetPath($targetFile);
 
-        $this->object->writeAsset($modifiedAsset);
+        $this->object->writeAsset($modifiedAsset, $factory);
 
         clearstatcache(true, $targetFile);
         $modifiedTargetMTime = filemtime($targetFile);
@@ -307,7 +309,8 @@ class Service extends \PHPUnit_Framework_TestCase
         $this->object->build();
 
         $manager = $this->object->getAssetManager();
-        $assets = $manager->get('base_css')->all();
+        $factory = $this->object->createAssetFactory($this->configuration->getModule('test_application'));
+        $assets  = $manager->get('base_css')->all();
 
         /** @var \Assetic\Asset\AssetInterface $asset */
         $asset = $assets[0];
@@ -318,7 +321,7 @@ class Service extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertFileNotExists($targetFile);
-        $this->object->writeAsset($asset);
+        $this->object->writeAsset($asset, $factory);
         $this->assertFileExists($targetFile);
 
         $sourceFile = $asset->getSourceRoot() . '/' . $asset->getSourcePath();
@@ -329,7 +332,7 @@ class Service extends \PHPUnit_Framework_TestCase
         $modifiedAsset = new FileAsset($sourceFile);
         $modifiedAsset->setTargetPath($targetFile);
 
-        $this->object->writeAsset($modifiedAsset);
+        $this->object->writeAsset($modifiedAsset, $factory);
 
         clearstatcache(true, $targetFile);
         $targetMTimeNotModified = filemtime($targetFile);


### PR DESCRIPTION
Assets are being written if the AsseticBundle detects the raw files being newer than the target file(s). The problem is that Assetic only checks the raw file that is directly configured; it misses any changes in imported files. This only applies if buildOnRequest == 1.

# Example:
We have an index.scss with this content:
```
@import "base/variables";
@import "base/reset";
@import "base/style";
```
And the index.scss is added to the bundle's configuration.

If we change anything in the index.scss, these change will be correctly reflected in the combined file. But if we change anything in the 3 imports (e. g. changing something in base/variables.scss) the combined file doesnt change. Because the assetic bundle only checks the mtime of the index.scss. (see https://github.com/widmogrod/zf2-assetic-module/blob/master/src/AsseticBundle/Service.php#L490)

# Assetic
Assetic fixed this bug in 1.1.0: they've added parsing of asset children to their filters. There is a method name "getLastModified()" in the asset factory that returns the max() of the mtime for the given asset and all its children.

# Change
Ive changed to AsseticBundle\Service::writeAsset() method to use the factories getLastModified() method instead of the getLastModified() method of the asset itself (which doesnt take its children into account).

# Consequences
*Upside:* Changes in dependent children will lead to an updated file of the collection.
*Downside:* I had to move the call of writeAsset() from the view helper to prepareCollection().

This means that every collections change will be written to disk on every request. The behavior before was that only changes of *used* collections will be written to disk. I had to do this because the writeAsset() method needs the factory the asset was created with. Another possibility would be saving its factory for every created assets and using it internally.

Opinions?