### PR TITLE
 CacheBuster: use AssetFactory::getLastModified($asset)

### DIFF
--- a/src/AsseticBundle/CacheBuster/LastModifiedStrategy.php
+++ b/src/AsseticBundle/CacheBuster/LastModifiedStrategy.php
@@ -13,7 +13,7 @@ class LastModifiedStrategy implements WorkerInterface
         $path = $asset->getTargetPath();
         $ext  = pathinfo($path, PATHINFO_EXTENSION);
 
-        $lastModified = $asset->getLastModified();
+        $lastModified = $factory->getLastModified($asset);
         if (null !== $lastModified) {
             $path = substr_replace(
                 $path,


### PR DESCRIPTION
This is an addendum to PR #153:

Using the asset factories getLastModified($asset) instead of the $asset->getLastModified() method enables that changes in dependent assets will lead to changes in the target file too.

This PR is to fix an oversight from the last PR (#153) where $asset->getLastModified() was replaced with $factory->getLastModified($asset) in the service. As it turns out there are two more occurances:
* the cache buster (this PR)
* the View Helper

The change needed for the cache buster was simple enough, but the view helper needs some refactoring to be able to use the correct last-modified-timestamp.

How do you want to proceed for the view helper?