### PR TITLE
AsseticBundle\CacheBuster\Null has deprecated

### DIFF
--- a/src/AsseticBundle/CacheBuster/NoCache.php
+++ b/src/AsseticBundle/CacheBuster/NoCache.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AsseticBundle\CacheBuster;
+
+use Assetic\Asset\AssetInterface,
+    Assetic\Factory\Worker\WorkerInterface,
+    Assetic\Factory\AssetFactory;
+
+class NoCache implements WorkerInterface
+{
+    public function process(AssetInterface $asset, AssetFactory $factory)
+    {
+    }
+}

--- a/src/AsseticBundle/CacheBuster/Null.php
+++ b/src/AsseticBundle/CacheBuster/Null.php
@@ -14,7 +14,7 @@ namespace AsseticBundle\CacheBuster;
  */
 class Null extends NoCache
 {
-    public function __construct($typeOrOptions = null)
+    public function __construct()
     {
         trigger_error(
             sprintf(

--- a/src/AsseticBundle/CacheBuster/Null.php
+++ b/src/AsseticBundle/CacheBuster/Null.php
@@ -2,13 +2,27 @@
 
 namespace AsseticBundle\CacheBuster;
 
-use Assetic\Asset\AssetInterface,
-    Assetic\Factory\Worker\WorkerInterface,
-    Assetic\Factory\AssetFactory;
-
-class Null implements WorkerInterface
+/**
+ * Stub class for backwards compatibility.
+ *
+ * Since PHP 7 adds "null" as a reserved keyword, we can no longer have a class
+ * named that and retain PHP 7 compatibility. The original class has been
+ * renamed to "NoCache", and this class is now an extension of it. It raises an
+ * E_USER_DEPRECATED to warn users to migrate.
+ *
+ * @deprecated
+ */
+class Null extends NoCache
 {
-    public function process(AssetInterface $asset, AssetFactory $factory)
+    public function __construct($typeOrOptions = null)
     {
+        trigger_error(
+            sprintf(
+                'The class %s has been deprecated; please use %s\\NoCache',
+                __CLASS__,
+                __NAMESPACE__
+            ),
+            E_USER_DEPRECATED
+        );
     }
 }


### PR DESCRIPTION
Since PHP 7 adds "null" as a reserved keyword, we can no longer have a class named that and retain PHP 7 compatibility.